### PR TITLE
chore: drop manifest version to `0.0.0`

### DIFF
--- a/custom_components/bazarr/manifest.json
+++ b/custom_components/bazarr/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://github.com/owenvoke/hass-bazarr",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/owenvoke/hass-bazarr/issues",
-  "version": "1.1.1"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This drops the manifest version to `0.0.0` to prevent needing to update it as part of the release flow.

Please check the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/main/CONTRIBUTING.md)** document for more information.
